### PR TITLE
Fix typescript issues and exports

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -20,15 +20,17 @@ export interface RenderProps {
 }
 
 export interface CarouselProps {
-  slidesToShow: number;
-  infinite: boolean;
-  transitionDuration: number;
-  centerCurrentSlide: boolean;
-  render: (props: RenderProps) => React.ReactElement;
+  slidesToShow?: number;
+  infinite?: boolean;
+  transitionDuration?: number;
+  centerCurrentSlide?: boolean;
+  render?: (props: RenderProps) => React.ReactElement;
 }
 
-const Carousel: React.FC<CarouselProps> = (
-  {
+export type RefInstance = Pick<RenderProps, "next" | "previous" | "goToStep">
+
+export default React.forwardRef<unknown, React.PropsWithChildren<CarouselProps>>(
+({
     children,
     slidesToShow = 3,
     infinite = true,
@@ -36,7 +38,7 @@ const Carousel: React.FC<CarouselProps> = (
     centerCurrentSlide = false,
     render = ({ slides }: RenderProps) => slides
   },
-  ref: () => void
+  ref
 ) => {
   const { slides, slideCount, preSlidesCount } = useSlides(children, {
     infinite,
@@ -52,7 +54,7 @@ const Carousel: React.FC<CarouselProps> = (
 
   const { previous, next, goToStep, currentIndex } = navigation;
 
-  React.useImperativeHandle(
+  React.useImperativeHandle<unknown, RefInstance>(
     ref,
     () => ({
       previous,
@@ -181,6 +183,4 @@ const Carousel: React.FC<CarouselProps> = (
     transitionDuration,
     centerCurrentSlide
   });
-};
-
-export default React.forwardRef(Carousel);
+});

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -20,7 +20,6 @@ export interface RenderProps {
 }
 
 export interface CarouselProps {
-  children: React.ReactElement;
   slidesToShow: number;
   infinite: boolean;
   transitionDuration: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { default as default, RenderProps, CarouselProps } from "./Carousel";
-export { generateDots } from "./dots";
+export { default, RefInstance, RenderProps, CarouselProps } from "./Carousel";
+export { generateDots, Dot } from "./dots";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
-import Carousel from "./Carousel";
-export default Carousel;
+export { default as default, RenderProps, CarouselProps } from "./Carousel";
 export { generateDots } from "./dots";

--- a/src/useSlides.ts
+++ b/src/useSlides.ts
@@ -7,7 +7,7 @@ interface Options {
 }
 
 function useSlides(
-  children: React.ReactElement,
+  children: React.ReactNode,
   { infinite, slidesToShow, mode = "flex" }: Options
 ) {
   return React.useMemo(() => {


### PR DESCRIPTION
Fixed some issues related to type errors/warnings and exports

* Carousel props have default values so `CarouselProps` should be optional
* Carousel props explicitly had `React.Element` for children which meant typescript complains when having multiple children (as in the examples). We don't actually need to type it, let `PropsWithChildren` handle that
* The `ref` was not typed (`() => void` ??). If we inline the Carousel component in `React.forwardRef` the type will be inferred automatically
* I created a `RefInstance` type and used it for `useImperativeHandle`. This can then be used by the user when creating their ref to get better autocompletion on `ref.current`
* Exported some more stuff that could be useful for the user

I am a but unsure about my RefInstance solution, I guess there could be a useCarouselRef hook that creates the ref so you don't need to manually set the type yourself (Like: `useRef<RefInstance>(null)`). Also a bit unsure how to type the ref in `forwardRef` and `useImperativeHandle` so just using unknown, e.g: `forwardRef<unknown, ...>`